### PR TITLE
feat: remove Node.js v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - '14'
   - '12'
   - '10'
-  - '8'
 before_install:
   - npm install -g npm
   - npm --version

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "8 || 10 || 12 || >=14"
+    "node": "10 || 12 || >=14"
   },
   "scripts": {
     "lint": "eslint *.js test/*.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is now the minimum supported version of
Node.js.